### PR TITLE
Misc fixes: Android back navigation, README update, UI tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,21 +116,6 @@ In Android Studio, select a target platform (Chrome web browser, Android
 Simulator, etc.) and then click on the `Run main.dart` button to build and the
 run the app on that platform. Shortcut : `Control + R` (macOS).
 
-### Run Widgetbook
-
-In Android Studio, select `Edit Configurations` in the Run menu. Copy
-configurations of main.dart and edit name as `widgetbook`. Edit
-`Dart entrypoint` to the path of your Widgetbook's main.dart. For e.g.
-`mm_flutter_app/widgetbook/main.dart` at the place of
-`mm_flutter_app/lib/main.dart`.
-
-Or to run from terminal, execute `flutter run -t widgetbook/main.dart`.
-
-### Run Tests
-
-In Android Studio, Open the test.dart file. Select the Run menu. Click the Run
-'tests in counter_test.dart' option.
-
 ### GraphQL Codegen
 
 The [GraphQL Codegen](https://pub.dev/documentation/graphql_codegen) package is

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:enableOnBackInvokedCallback="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/lib/widgets/shared/radio_button_cards.dart
+++ b/lib/widgets/shared/radio_button_cards.dart
@@ -50,71 +50,76 @@ class _RadioButtonCardsState extends State<RadioButtonCards> {
       }
 
       cardWidgets.add(
-        Container(
-          decoration: BoxDecoration(
-            color: startingColor,
-            borderRadius: BorderRadius.circular(Radii.roundedRectRadiusSmall),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(Insets.paddingSmall),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Expanded(
-                  flex: 1,
-                  child: Radio<int>(
-                    value: i,
-                    groupValue: _character,
-                    onChanged: (int? value) {
-                      setState(() {
-                        _character = value!;
-                        if (widget.onSelectedCardChanged != null) {
-                          widget.onSelectedCardChanged!(_character);
-                        }
-                      });
-                    },
+        InkWell(
+          onTap: () => setState(() => _character = i),
+          child: Container(
+            decoration: BoxDecoration(
+              color: startingColor,
+              borderRadius: BorderRadius.circular(Radii.roundedRectRadiusSmall),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(Insets.paddingSmall),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Expanded(
+                    flex: 1,
+                    child: Radio<int>(
+                      value: i,
+                      groupValue: _character,
+                      onChanged: (int? value) {
+                        setState(() {
+                          _character = value!;
+                          if (widget.onSelectedCardChanged != null) {
+                            widget.onSelectedCardChanged!(_character);
+                          }
+                        });
+                      },
+                    ),
                   ),
-                ),
-                if (widget.imageAssetName[i] != null)
-                  SizedBox(
-                    width: 64,
-                    height: 104,
-                    child: widget.imageAssetName[i],
-                  ),
-                if (widget.imageAssetName[i] != null) const SizedBox(width: 16),
-                Expanded(
-                  flex: 3,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.only(
-                            top: Insets.paddingSmall,
-                            bottom: Insets.paddingSmall),
-                        child: Row(
-                          children: [
-                            //the code snippet below checks if the titleIcon is null, and if it is not null, presents it
-                            if (widget.titleIcon[i] != null)
-                              widget.titleIcon[i]!,
-                            if (widget.titleIcon[i] != null)
-                              const SizedBox(
-                                width: Insets.paddingExtraSmall,
+                  if (widget.imageAssetName[i] != null)
+                    SizedBox(
+                      width: 64,
+                      height: 104,
+                      child: widget.imageAssetName[i],
+                    ),
+                  if (widget.imageAssetName[i] != null)
+                    const SizedBox(width: 16),
+                  Expanded(
+                    flex: 3,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.only(
+                            bottom: Insets.paddingSmall,
+                          ),
+                          child: Row(
+                            children: [
+                              //the code snippet below checks if the titleIcon is null, and if it is not null, presents it
+                              if (widget.titleIcon[i] != null)
+                                widget.titleIcon[i]!,
+                              if (widget.titleIcon[i] != null)
+                                const SizedBox(
+                                  width: Insets.paddingExtraSmall,
+                                ),
+                              Text(
+                                widget.title[i],
+                                style: theme.textTheme.titleMedium,
                               ),
-                            Text(
-                              widget.title[i],
-                              style: theme.textTheme.titleMedium,
-                            ),
-                          ],
+                            ],
+                          ),
                         ),
-                      ),
-                      Text(
-                        widget.subtitle[i],
-                        style: theme.textTheme.bodySmall,
-                      ),
-                    ],
-                  ),
-                )
-              ],
+                        Text(
+                          widget.subtitle[i],
+                          style: theme.textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
+                  )
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
- Per UX request, make entire radio button card (used during signup flow user type and business stage selection) clickable. Adjust paddings.
- Fixes issues with handling the Android device's back button on API 34+, which would always cause the app to be closed instead of navigating to the previous page. The fix involves removing an entry from the Android manifest, which is suggested in [this issue](https://github.com/flutter/flutter/issues/117061).
- Remove sections on Widgetbook and testing from the README, since the app currently doesn't support these. This was done to avoid confusing new engineers and partners reading the document.